### PR TITLE
error with seeds

### DIFF
--- a/backend/db/seeders/20240517040652-demo-spot.js
+++ b/backend/db/seeders/20240517040652-demo-spot.js
@@ -87,7 +87,7 @@ module.exports = {
 
     ], { validate: true })
   } catch(e) {
-    console.log(error);
+    console.log(e);
   }
   
 


### PR DESCRIPTION
spelled console.log(error) instead of just console.log(e)