### PR TITLE
Manage spots

### DIFF
--- a/backend/routes/api/spots.js
+++ b/backend/routes/api/spots.js
@@ -258,6 +258,7 @@ router.get('/', queryParams, async (req, res, next) => {
 router.get('/current', requireAuth, async (req, res, next) => {
     try {
         const { user } = req;
+        
         if (user) {
             const spots = await Spot.findAll({
                 where: {

--- a/backend/routes/api/spots.js
+++ b/backend/routes/api/spots.js
@@ -330,11 +330,12 @@ router.post('/', requireAuth, validateNewSpot, async (req, res, next) => {
             country, lat, lng, name,
             description, price } = req.body;
 
-
+            console.log(address)
         const { user } = req;
+        console.log(user)
 
         if (user) {
-            
+             
 
             const newSpot = await Spot.create({
                 ownerId: user.id, address, city,
@@ -371,8 +372,10 @@ router.post('/:spotId/images', requireAuth, async (req, res, next) => {
     try {
         const { url, preview } = req.body;
         const { spotId } = req.params;
+        console.log(url)
 
         const spot = await Spot.findByPk(spotId);
+        console.log('spot', spot)
 
         const { user } = req;
 
@@ -388,6 +391,8 @@ router.post('/:spotId/images', requireAuth, async (req, res, next) => {
                 const newImage = await SpotImage.create({
                     url, preview, spotId: parseInt(spotId)
                 });
+
+                console.log('newimage', newImage)
                 const imageFormatting = {
                     id: newImage.id,
                     url: newImage.url,

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,6 +6,7 @@ import * as sessionActions from './store/session';
 import Header from "./components/Header/Header";
 import Splash from "./screens/Splash/components/Splash";
 import Spot from "./screens/Spot/components/Spot/Spot";
+import SpotForm from "./screens/CreateSpot/components/main/SpotForm";
 
 function Layout() {
   const dispatch = useDispatch();
@@ -35,6 +36,10 @@ const router = createBrowserRouter([
       {
         path: '/spots/:id',
         element: <Spot />
+      },
+      {
+        path: '/spots/new',
+        element: <SpotForm />
       }
 
     ]

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,6 +7,7 @@ import Header from "./components/Header/Header";
 import Splash from "./screens/Splash/components/Splash";
 import Spot from "./screens/Spot/components/Spot/Spot";
 import SpotForm from "./screens/CreateSpot/components/main/SpotForm";
+import ManageSpots from "./screens/ManageSpots/Components/ManageSpots";
 
 function Layout() {
   const dispatch = useDispatch();
@@ -40,6 +41,10 @@ const router = createBrowserRouter([
       {
         path: '/spots/new',
         element: <SpotForm />
+      },
+      {
+        path: '/spots/manage',
+        element: <ManageSpots />
       }
 
     ]

--- a/frontend/src/components/Header/Navigation/ProfileButton.jsx
+++ b/frontend/src/components/Header/Navigation/ProfileButton.jsx
@@ -1,26 +1,35 @@
 import { useState, useEffect, useRef } from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { FaUserCircle } from 'react-icons/fa';
 import * as sessionActions from '../../../store/session';
 import OpenModalMenuItem from './OpenModalMenuItem';
 import LoginFormModal from '../../Modal/LoginFormModal/LoginFormModal';
 import SignupFormModal from '../../Modal/SignupFormModal/SignupFormModal';
 import { GiHamburgerMenu } from "react-icons/gi";
-import { useNavigate } from 'react-router-dom';
+import { NavLink, useNavigate } from 'react-router-dom';
+import { getCurrentUserSpotsThunk } from '../../../store/spots';
 
 function ProfileButton({ user }) {
   const dispatch = useDispatch();
   const [showMenu, setShowMenu] = useState(false);
   const ulRef = useRef();
   const navigate = useNavigate();
+  
+  const spots = useSelector(state => state.spotState.currentUser)
+  
 
   const toggleMenu = (e) => {
     e.stopPropagation(); // Keep from bubbling up to document and triggering closeMenu
     setShowMenu(!showMenu);
   };
 
+  
+
+  
+
   useEffect(() => {
     if (!showMenu) return;
+    
 
     const closeMenu = (e) => {
       if (!ulRef.current.contains(e.target)) {
@@ -57,7 +66,7 @@ function ProfileButton({ user }) {
             <li>{user.email}</li>
             </div>
             <div className='manageSpots cursor'>
-            <li> {<div onClick={() => navigate('/spots/manage')}>Manage Spots</div>}</li>
+            <li> { spots ? <div onClick={() => navigate('/spots/manage')}>Manage Spots</div> : <NavLink to={'/spots/new'} >Create a New Spot</NavLink> }</li>
             <li>Manage Reviews</li>
             </div>
             <li className='logout'>

--- a/frontend/src/components/Header/Navigation/ProfileButton.jsx
+++ b/frontend/src/components/Header/Navigation/ProfileButton.jsx
@@ -57,7 +57,7 @@ function ProfileButton({ user }) {
             <li>{user.email}</li>
             </div>
             <div className='manageSpots cursor'>
-            <li> <div onClick={() => navigate('/spots/manage')}>Manage Spots</div></li>
+            <li> {<div onClick={() => navigate('/spots/manage')}>Manage Spots</div>}</li>
             <li>Manage Reviews</li>
             </div>
             <li className='logout'>

--- a/frontend/src/components/Header/Navigation/ProfileButton.jsx
+++ b/frontend/src/components/Header/Navigation/ProfileButton.jsx
@@ -6,11 +6,13 @@ import OpenModalMenuItem from './OpenModalMenuItem';
 import LoginFormModal from '../../Modal/LoginFormModal/LoginFormModal';
 import SignupFormModal from '../../Modal/SignupFormModal/SignupFormModal';
 import { GiHamburgerMenu } from "react-icons/gi";
+import { useNavigate } from 'react-router-dom';
 
 function ProfileButton({ user }) {
   const dispatch = useDispatch();
   const [showMenu, setShowMenu] = useState(false);
   const ulRef = useRef();
+  const navigate = useNavigate();
 
   const toggleMenu = (e) => {
     e.stopPropagation(); // Keep from bubbling up to document and triggering closeMenu
@@ -55,7 +57,7 @@ function ProfileButton({ user }) {
             <li>{user.email}</li>
             </div>
             <div className='manageSpots cursor'>
-            <li>Manage Spots</li>
+            <li> <div onClick={() => navigate('/spots/manage')}>Manage Spots</div></li>
             <li>Manage Reviews</li>
             </div>
             <li className='logout'>

--- a/frontend/src/components/Header/spotButton/SpotButton.jsx
+++ b/frontend/src/components/Header/spotButton/SpotButton.jsx
@@ -1,12 +1,13 @@
 
 import { useSelector } from 'react-redux';
+import { NavLink } from 'react-router-dom';
 
 export default function SpotButton() {
     const sessionUser = useSelector(state => state.session.user);
   return (
     <>
     {sessionUser ? (<div className='createSpotLink'>
-        Create a New Spot
+        <NavLink to={'/spots/new'} >Create a New Spot</NavLink>
     </div>) : null}
     </>
   )

--- a/frontend/src/components/Modal/LoginFormModal/LoginFormModal.jsx
+++ b/frontend/src/components/Modal/LoginFormModal/LoginFormModal.jsx
@@ -10,6 +10,7 @@ export default function LoginFormModal() {
     const [password, setPassword] = useState('');
     const [errors, setErrors] = useState({});
     const { closeModal } = useModal();
+    
 
     const demoLogin = (e) => {
         e.preventDefault();

--- a/frontend/src/components/Modal/LoginFormModal/LoginFormModal.jsx
+++ b/frontend/src/components/Modal/LoginFormModal/LoginFormModal.jsx
@@ -11,6 +11,19 @@ export default function LoginFormModal() {
     const [errors, setErrors] = useState({});
     const { closeModal } = useModal();
 
+    const demoLogin = (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        return dispatch(sessionActions.login({credential: 'FakeUser1', password: 'password2'})).then(closeModal)
+        .catch(
+            async (res) => {
+                const data = await res.json();
+                if (data?.errors) setErrors(data.errors);
+            }
+        );
+
+    }
+
     const handleSubmit = (e) => {
         e.preventDefault();
         e.stopPropagation();
@@ -48,6 +61,7 @@ export default function LoginFormModal() {
             {errors.credential && <p>{errors.credential}</p>}
             <button type='submit'>Log In</button>
         </label>
+        <button onClick={(e) => demoLogin(e)}>log in as demo user</button>
     </form>
     </>
   )

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -17,3 +17,6 @@
     
 }
 
+.colorInput {
+    background-color: #e9f0fe;
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -20,3 +20,4 @@
 .colorInput {
     background-color: #e9f0fe;
 }
+

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -21,3 +21,9 @@
     background-color: #e9f0fe;
 }
 
+.red button {
+    background-color: #FF385c;
+    border-radius: .4rem;
+    box-shadow: 1px 1px 1px black;
+    color: white;
+}

--- a/frontend/src/screens/CreateSpot/components/main/SpotForm.css
+++ b/frontend/src/screens/CreateSpot/components/main/SpotForm.css
@@ -1,8 +1,9 @@
-.formDiv {
+.form {
     max-width: 1000px;
     display: flex;
-    flex-direction: column;
-    align-items: center;
+    margin-left: auto;
+    margin-right: auto;
+    justify-content: center;
 }
 
 .onlyShows {
@@ -12,12 +13,13 @@
 .location {
     display: flex;
     flex-direction: column;
-    margin-left: auto;
-    
     /* align-items: center; */
 }
 
 .location h2 {
+    margin-bottom: .3rem;
+}
+.descriptionSub {
     margin-bottom: .3rem;
 }
 
@@ -36,7 +38,11 @@
     margin-right: .5rem;
 }
 .cityInput {
-    width: 30rem;
+    width: 40rem;
+}
+
+.stateInput {
+    width: 20rem;
 }
 .city {
     display: flex;
@@ -64,16 +70,31 @@
     gap: 1rem;
     border-bottom: 2px solid black;
     padding-bottom: 2rem;
+    /* align-items: center; */
+}
+
+#description {
+    height: 5rem;
+}
+.section2 {
+    display: flex;
+    flex-direction: column;
+    /* align-items: center; */
+    
+    border-bottom: 2px solid black;
+    padding-bottom: 2rem;
 }
 
 .longInput {
     
-    width: 41rem;
+    width: 100%;
 }
 .lat {
-    width: 20rem;
+    width: 30rem;
 }
 .lng {
-    width: 19rem;
+    width: 30rem;
 }
+
+
 

--- a/frontend/src/screens/CreateSpot/components/main/SpotForm.css
+++ b/frontend/src/screens/CreateSpot/components/main/SpotForm.css
@@ -28,6 +28,16 @@
     display: flex;
     gap: .3rem;
 }
+
+.labelAndError {
+    display: flex;
+    flex-direction: row;
+    gap: 1rem;
+}
+
+.error {
+    color: #FF385c;
+}
 .location {
     display: flex;
     flex-direction: column;

--- a/frontend/src/screens/CreateSpot/components/main/SpotForm.css
+++ b/frontend/src/screens/CreateSpot/components/main/SpotForm.css
@@ -1,0 +1,79 @@
+.formDiv {
+    max-width: 1000px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.onlyShows {
+    margin-top: 0;
+    margin-bottom: 2rem;
+}
+.location {
+    display: flex;
+    flex-direction: column;
+    margin-left: auto;
+    
+    /* align-items: center; */
+}
+
+.location h2 {
+    margin-bottom: .3rem;
+}
+
+.labelTop {
+    display: flex;
+    flex-direction: column;
+    gap: .3rem;
+
+}
+
+.cityState {
+    display: flex;
+    flex-direction: row;
+}
+.cityLabel {
+    margin-right: .5rem;
+}
+.cityInput {
+    width: 30rem;
+}
+.city {
+    display: flex;
+    flex-direction: column;
+    gap: .3rem;
+}
+.state {
+    display: flex;
+    flex-direction: column;
+    gap: .3rem;
+}
+
+.comma {
+    margin-left: .3rem;
+    margin-right: 1rem;
+    align-self: flex-end;
+}
+.stateLabel {
+    margin-right: .5rem;
+}
+
+.sectionOne {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    border-bottom: 2px solid black;
+    padding-bottom: 2rem;
+}
+
+.longInput {
+    
+    width: 41rem;
+}
+.lat {
+    width: 20rem;
+}
+.lng {
+    width: 19rem;
+}
+

--- a/frontend/src/screens/CreateSpot/components/main/SpotForm.css
+++ b/frontend/src/screens/CreateSpot/components/main/SpotForm.css
@@ -8,7 +8,25 @@
 
 .onlyShows {
     margin-top: 0;
-    margin-bottom: 2rem;
+    
+}
+
+.imageInputs {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.buttonDiv {
+    margin-top: 1rem;
+    margin-left: auto;
+    margin-right: auto;
+    padding-bottom: 1rem;
+}
+
+.priceInput {
+    display: flex;
+    gap: .3rem;
 }
 .location {
     display: flex;
@@ -62,6 +80,13 @@
 }
 .stateLabel {
     margin-right: .5rem;
+}
+
+.red {
+    background-color: #FF385c;
+    border-radius: .4rem;
+    box-shadow: 1px 1px 1px black;
+    color: white;
 }
 
 .sectionOne {

--- a/frontend/src/screens/CreateSpot/components/main/SpotForm.jsx
+++ b/frontend/src/screens/CreateSpot/components/main/SpotForm.jsx
@@ -18,11 +18,16 @@ export default function SpotForm() {
   const [imageThree, setImageThree] = useState('')
   const [imageFour, setImageFour] = useState('')
   const [errors, setErrors] = useState({});
+  const [buttonClicked, setButtonClicked] = useState(false)
 
   const dispatch = useDispatch();
 
   useEffect(() => {
     const error = {};
+
+    if (buttonClicked) {
+
+    
     if (!country.length) {
       error.country = 'Country is required';
     }
@@ -89,12 +94,14 @@ export default function SpotForm() {
         error.imageFour = 'Image URL must end in .png, .jpg, or .jpeg'
       }
     }
+  }
     setErrors(error)
-  }, [country, street, state, city, lat, lng, description, name, price, previewImage, imageOne, imageTwo, imageThree, imageFour])
+  }, [country, street, state, city, lat, lng, description, name, price, previewImage, imageOne, imageTwo, imageThree, imageFour, buttonClicked])
 
 
 
   const submit = (e) => {
+    setButtonClicked(!buttonClicked)
     e.preventDefault();
     e.stopPropagation();
 
@@ -312,7 +319,7 @@ export default function SpotForm() {
 
           <button
             onClick={(e) => submit(e)}
-            // disabled={Object.keys(errors).length}
+            
             className='red'
           >Create Spot</button>
         </div>

--- a/frontend/src/screens/CreateSpot/components/main/SpotForm.jsx
+++ b/frontend/src/screens/CreateSpot/components/main/SpotForm.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import './SpotForm.css'
+import { useDispatch } from 'react-redux';
 
 export default function SpotForm() {
   const [country, setCountry] = useState('');
@@ -9,8 +10,24 @@ export default function SpotForm() {
   const [lat, setLat] = useState('');
   const [lng, setLng] = useState('');
   const [description, setDescription] = useState('')
+  const [name, setName] = useState('');
+  const [price, setPrice] = useState('');
+  const [previewImage, setPreviewImage] = useState('');
+  const [imageOne, setImageOne] = useState('')
+  const [imageTwo, setImageTwo] = useState('')
+  const [imageThree, setImageThree] = useState('')
+  const [imageFour, setImageFour] = useState('')
+  const [errors, setErrors] = useState({});
+
+  const dispatch = useDispatch();
 
 
+
+  const submit = (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+  }
 
   return (
     <div className="form">
@@ -95,15 +112,95 @@ export default function SpotForm() {
           <h2 className='subheading bottom'>Describe your place to guests</h2>
           <p className='normal onlyShows'>Mention the best features of your space, any special amentities like fast wifi or parking, and what you love about the neighborhood.</p>
           <textarea
-          className='colorInput longInput'
-          placeholder='Please write at least 30 characters'
-          name="description"
-          id="description"
-          value={description}
-          onChange={e => setDescription(e.target.value)}
+            className='colorInput longInput'
+            placeholder='Please write at least 30 characters'
+            name="description"
+            id="description"
+            value={description}
+            onChange={e => setDescription(e.target.value)}
           ></textarea>
+        </div>
+        <div className='section2'>
+          <h2 className='subheading bottom'>Create a title for your spot</h2>
+          <p className='normal onlyShows'>Catch guests&apos; attention with a spot title that highlights what makes your place special.</p>
+          <input
+            className='colorInput longInput'
+            type="text"
+            placeholder='Name of your spot'
+            value={name}
+            onChange={e => setName(e.target.value)}
+          />
+        </div>
+        <div className='section2'>
+          <h2 className='subheading bottom'>Set a base price for your spot</h2>
+          <p className='normal onlyShows'>Competitive pricing can help your listing stand out and rank higher in search results.</p>
+
+          <div className='priceInput'>
+            <div className='normal'>$</div>
+            <input
+              className='colorInput longInput'
+              type="text"
+              placeholder='Name of your spot'
+              value={price}
+              onChange={e => setPrice(e.target.value)}
+            />
+          </div>
+        </div>
+        <div className='section2'>
+          <h2 className='subheading bottom'>Liven up your spot with photos</h2>
+          <p className='normal onlyShows'>Submit a link to at least one photo to publish your spot..</p>
+
+          <div className='imageInputs'>
+
+            <input
+              className='colorInput longInput'
+              type="url"
+
+              placeholder='Preview Image URL'
+              value={previewImage}
+              onChange={e => setPreviewImage(e.target.value)}
+            />
+            <input
+              className='colorInput longInput'
+              type="url"
+
+              placeholder='Image URL'
+              value={imageOne}
+              onChange={e => setImageOne(e.target.value)}
+            />
+            <input
+              className='colorInput longInput'
+              type="url"
+
+              placeholder='Image URL'
+              value={imageTwo}
+              onChange={e => setImageTwo(e.target.value)}
+            />
+            <input
+              className='colorInput longInput'
+              type="url"
+
+              placeholder='Image URL'
+              value={imageThree}
+              onChange={e => setImageThree(e.target.value)}
+            />
+            <input
+              className='colorInput longInput'
+              type="url"
+
+              placeholder='Image URL'
+              value={imageFour}
+              onChange={e => setImageFour(e.target.value)}
+            />
+          </div>
 
         </div>
+
+          <div className='buttonDiv'>
+            <button onClick={(e) => submit(e)} className='red'>Create Spot</button>
+          </div>
+
+
 
       </div>
 

--- a/frontend/src/screens/CreateSpot/components/main/SpotForm.jsx
+++ b/frontend/src/screens/CreateSpot/components/main/SpotForm.jsx
@@ -112,6 +112,10 @@ export default function SpotForm() {
     setButtonClicked(!buttonClicked)
     e.preventDefault();
     e.stopPropagation();
+
+  
+
+
     const spot = { country, address, state, city, lat, lng, description, name, price }
     const newSpot = await dispatch(addSpotThunk(spot))
 

--- a/frontend/src/screens/CreateSpot/components/main/SpotForm.jsx
+++ b/frontend/src/screens/CreateSpot/components/main/SpotForm.jsx
@@ -105,7 +105,7 @@ export default function SpotForm() {
     }
     setErrors(error)
     console.log(Object.keys(errors))
-  }, [country, address, state, city, lat, lng, description, name, price, previewImage, imageOne, imageTwo, imageThree, imageFour, buttonClicked])
+  }, [country, address, state, city, lat, lng, description, name, price, previewImage, imageOne, imageTwo, imageThree, imageFour, buttonClicked, errors])
 
 
 

--- a/frontend/src/screens/CreateSpot/components/main/SpotForm.jsx
+++ b/frontend/src/screens/CreateSpot/components/main/SpotForm.jsx
@@ -1,0 +1,98 @@
+import { useState } from 'react';
+import './SpotForm.css'
+
+export default function SpotForm() {
+    const [country, setCountry] = useState('');
+    const [street, setStreet] = useState('');
+    const [city, setCity] = useState('');
+    const [state, setState] = useState('');
+    const [lat, setLat] = useState('');
+    const [lng, setLng] = useState('');
+
+
+
+  return (
+    <div className="formDiv">
+        <div  className="location">
+        <h1 className="heading">Create a new Spot</h1>
+        <h2 className="subheading">Where&apos;s your place Located?</h2>
+        <p className="normal onlyShows">Guests will only get your exact address once they booked a reservation.</p>
+
+        <div className='sectionOne'>
+        <div className='country labelTop'>
+            <label htmlFor="country">Country</label>
+            <input 
+            className='longInput colorInput'
+            type="text" 
+            placeholder='Country'
+            value={country}
+            onChange={e => setCountry(e.target.value)}
+            />
+        </div>
+        <div className='streetAddress labelTop'><label htmlFor="street">Street Address</label>
+        <input 
+        className='longInput colorInput'
+        type="text"
+        placeholder='Street Address'
+        value={street}
+        onChange={e => setStreet(e.target.value)}
+         />
+        </div>
+        <div className='cityState'>
+            <div className='city'>
+
+            <label className='cityLabel' htmlFor="city">City</label>
+            <input 
+            className='cityInput colorInput'
+            type="text"
+            placeholder='City'
+            value={city}
+            onChange={e => setCity(e.target.value)}
+             />
+            </div>
+             <div className='normal comma'>,</div>
+            <div className='state'>
+
+             <label className='stateLabel' htmlFor="state">State</label>
+             <input 
+             className='stateInput colorInput'
+             type="text"
+             placeholder='State'
+             value={state}
+             onChange={e => setState(e.target.value)}
+              />
+            </div>
+        </div>
+        <div className='cityState'>
+            <div className='city'>
+
+            <label className='cityLabel' htmlFor="city">Latitude</label>
+            <input 
+            className='lat colorInput'
+            type="text"
+            placeholder='Latitude'
+            value={lat}
+            onChange={e => setLat(e.target.value)}
+             />
+            </div>
+             <div className='normal comma'>,</div>
+            <div className='state'>
+
+             <label className='stateLabel' htmlFor="state">Longitude</label>
+             <input 
+             className='lng colorInput'
+             type="text"
+             placeholder='Longitude'
+             value={lng}
+             onChange={e => setLng(e.target.value)}
+              />
+            </div>
+        </div>
+
+        </div>
+
+        </div>
+
+    </div>
+  )
+}

--- a/frontend/src/screens/CreateSpot/components/main/SpotForm.jsx
+++ b/frontend/src/screens/CreateSpot/components/main/SpotForm.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import './SpotForm.css'
 import { useDispatch } from 'react-redux';
 
@@ -21,6 +21,77 @@ export default function SpotForm() {
 
   const dispatch = useDispatch();
 
+  useEffect(() => {
+    const error = {};
+    if (!country.length) {
+      error.country = 'Country is required';
+    }
+
+    if (!street.length) {
+      error.street = 'Address is required';
+    }
+
+    if (!city.length) {
+      error.city = 'City is required';
+    }
+
+    if (!state.length) {
+      error.state = 'State is required';
+    }
+
+    if (!lat.length) {
+      error.lat = 'Latitude is required';
+    }
+
+    if (!lng.length) {
+      error.lng = 'Longitude is required';
+    }
+
+    if (description.length < 30) {
+      error.description = 'Description needs a minimum of 30 characters';
+    }
+
+    if (!name.length) {
+      error.name = 'Name is required';
+    }
+
+    if (!price.length) {
+      error.price = 'Price is required';
+    }
+
+    if (!previewImage.length) {
+      error.preview = 'Preview Image is required'
+    }
+    if (previewImage.length) {
+      if (!previewImage.endsWith('.png') && !previewImage.endsWith('.jpg') && !previewImage.endsWith('.jpeg')) {
+        error.image = 'Image URL must end in .png, .jpg, or .jpeg'
+      }
+    }
+
+    if (imageOne.length) {
+      if (!imageOne.endsWith('.png') && !imageOne.endsWith('.jpg') && !imageOne.endsWith('.jpeg')) {
+        error.imageOne = 'Image URL must end in .png, .jpg, or .jpeg'
+      }
+    }
+
+    if (imageTwo.length) {
+      if (!imageTwo.endsWith('.png') && !imageTwo.endsWith('.jpg') && !imageTwo.endsWith('.jpeg')) {
+        error.imageTwo = 'Image URL must end in .png, .jpg, or .jpeg'
+      }
+    }
+    if (imageThree.length) {
+      if (!imageThree.endsWith('.png') && !imageThree.endsWith('.jpg') && !imageThree.endsWith('.jpeg')) {
+        error.imageThree = 'Image URL must end in .png, .jpg, or .jpeg'
+      }
+    }
+    if (imageFour.length) {
+      if (!imageFour.endsWith('.png') && !imageFour.endsWith('.jpg') && !imageFour.endsWith('.jpeg')) {
+        error.imageFour = 'Image URL must end in .png, .jpg, or .jpeg'
+      }
+    }
+    setErrors(error)
+  }, [country, street, state, city, lat, lng, description, name, price, previewImage, imageOne, imageTwo, imageThree, imageFour])
+
 
 
   const submit = (e) => {
@@ -38,7 +109,10 @@ export default function SpotForm() {
 
         <div className='sectionOne'>
           <div className='country labelTop'>
-            <label htmlFor="country">Country</label>
+            <div className='labelAndError'>
+              <label htmlFor="country">Country</label>
+              <div className='error'>{errors.country && errors.country}</div>
+            </div>
             <input
               className='longInput colorInput'
               type="text"
@@ -47,7 +121,11 @@ export default function SpotForm() {
               onChange={e => setCountry(e.target.value)}
             />
           </div>
-          <div className='streetAddress labelTop'><label htmlFor="street">Street Address</label>
+          <div className='streetAddress labelTop'>
+            <div className='labelAndError'>
+              <label htmlFor="street">Street Address</label>
+              <div className='error'>{errors.street && errors.street}</div>
+            </div>
             <input
               className='longInput colorInput'
               type="text"
@@ -58,8 +136,11 @@ export default function SpotForm() {
           </div>
           <div className='cityState'>
             <div className='city'>
+              <div className='labelAndError'>
+                <label className='cityLabel' htmlFor="city">City</label>
+                <div className='error'>{errors.city && errors.city}</div>
 
-              <label className='cityLabel' htmlFor="city">City</label>
+              </div>
               <input
                 className='cityInput colorInput'
                 type="text"
@@ -70,8 +151,11 @@ export default function SpotForm() {
             </div>
             <div className='normal comma'>,</div>
             <div className='state'>
-
+              <div className='labelAndError'>
               <label className='stateLabel' htmlFor="state">State</label>
+              <div className='error'>{errors.state && errors.state}</div>
+
+              </div>
               <input
                 className='stateInput colorInput'
                 type="text"
@@ -83,8 +167,11 @@ export default function SpotForm() {
           </div>
           <div className='cityState'>
             <div className='city'>
+            <div className='labelAndError'>
+              <label className='cityLabel' htmlFor="latitude">Latitude</label>
+              <div className='error'>{errors.lat && errors.lat}</div>
 
-              <label className='cityLabel' htmlFor="city">Latitude</label>
+            </div>
               <input
                 className='lat colorInput'
                 type="text"
@@ -95,8 +182,12 @@ export default function SpotForm() {
             </div>
             <div className='normal comma'>,</div>
             <div className='state'>
+            <div className='labelAndError'>
+              <label className='stateLabel' htmlFor="longitude">Longitude</label>
+              <div className='error'>{errors.lng && errors.lng}</div>
 
-              <label className='stateLabel' htmlFor="state">Longitude</label>
+            </div>
+
               <input
                 className='lng colorInput'
                 type="text"
@@ -119,6 +210,7 @@ export default function SpotForm() {
             value={description}
             onChange={e => setDescription(e.target.value)}
           ></textarea>
+          <div className='error'>{errors.description && errors.description}</div>
         </div>
         <div className='section2'>
           <h2 className='subheading bottom'>Create a title for your spot</h2>
@@ -130,6 +222,7 @@ export default function SpotForm() {
             value={name}
             onChange={e => setName(e.target.value)}
           />
+          <div className='error'>{errors.name && errors.name}</div>
         </div>
         <div className='section2'>
           <h2 className='subheading bottom'>Set a base price for your spot</h2>
@@ -145,13 +238,14 @@ export default function SpotForm() {
               onChange={e => setPrice(e.target.value)}
             />
           </div>
+            <div className='error'>{errors.price && errors.price}</div>
         </div>
         <div className='section2'>
           <h2 className='subheading bottom'>Liven up your spot with photos</h2>
           <p className='normal onlyShows'>Submit a link to at least one photo to publish your spot..</p>
 
           <div className='imageInputs'>
-
+            <div>
             <input
               className='colorInput longInput'
               type="url"
@@ -160,6 +254,10 @@ export default function SpotForm() {
               value={previewImage}
               onChange={e => setPreviewImage(e.target.value)}
             />
+            <div className='error'>{errors.preview && errors.preview || errors.image && errors.image}</div>
+
+            </div>
+            <div>
             <input
               className='colorInput longInput'
               type="url"
@@ -168,6 +266,10 @@ export default function SpotForm() {
               value={imageOne}
               onChange={e => setImageOne(e.target.value)}
             />
+            <div className='error'>{errors.imageOne && errors.imageOne}</div>
+
+            </div>
+            <div>
             <input
               className='colorInput longInput'
               type="url"
@@ -176,6 +278,10 @@ export default function SpotForm() {
               value={imageTwo}
               onChange={e => setImageTwo(e.target.value)}
             />
+            <div className='error'>{errors.imageTwo && errors.imageTwo}</div>
+
+            </div>
+            <div>
             <input
               className='colorInput longInput'
               type="url"
@@ -184,6 +290,10 @@ export default function SpotForm() {
               value={imageThree}
               onChange={e => setImageThree(e.target.value)}
             />
+            <div className='error'>{errors.imageThree && errors.imageThree}</div>
+
+            </div>
+            <div>
             <input
               className='colorInput longInput'
               type="url"
@@ -192,13 +302,20 @@ export default function SpotForm() {
               value={imageFour}
               onChange={e => setImageFour(e.target.value)}
             />
+              <div className='error'>{errors.imageFour && errors.imageFour}</div>
+            </div>
           </div>
 
         </div>
 
-          <div className='buttonDiv'>
-            <button onClick={(e) => submit(e)} className='red'>Create Spot</button>
-          </div>
+        <div className='buttonDiv'>
+
+          <button
+            onClick={(e) => submit(e)}
+            // disabled={Object.keys(errors).length}
+            className='red'
+          >Create Spot</button>
+        </div>
 
 
 

--- a/frontend/src/screens/CreateSpot/components/main/SpotForm.jsx
+++ b/frontend/src/screens/CreateSpot/components/main/SpotForm.jsx
@@ -2,96 +2,110 @@ import { useState } from 'react';
 import './SpotForm.css'
 
 export default function SpotForm() {
-    const [country, setCountry] = useState('');
-    const [street, setStreet] = useState('');
-    const [city, setCity] = useState('');
-    const [state, setState] = useState('');
-    const [lat, setLat] = useState('');
-    const [lng, setLng] = useState('');
+  const [country, setCountry] = useState('');
+  const [street, setStreet] = useState('');
+  const [city, setCity] = useState('');
+  const [state, setState] = useState('');
+  const [lat, setLat] = useState('');
+  const [lng, setLng] = useState('');
+  const [description, setDescription] = useState('')
 
 
 
   return (
-    <div className="formDiv">
-        <div  className="location">
+    <div className="form">
+      <div className="location">
         <h1 className="heading">Create a new Spot</h1>
         <h2 className="subheading">Where&apos;s your place Located?</h2>
         <p className="normal onlyShows">Guests will only get your exact address once they booked a reservation.</p>
 
         <div className='sectionOne'>
-        <div className='country labelTop'>
+          <div className='country labelTop'>
             <label htmlFor="country">Country</label>
-            <input 
-            className='longInput colorInput'
-            type="text" 
-            placeholder='Country'
-            value={country}
-            onChange={e => setCountry(e.target.value)}
+            <input
+              className='longInput colorInput'
+              type="text"
+              placeholder='Country'
+              value={country}
+              onChange={e => setCountry(e.target.value)}
             />
-        </div>
-        <div className='streetAddress labelTop'><label htmlFor="street">Street Address</label>
-        <input 
-        className='longInput colorInput'
-        type="text"
-        placeholder='Street Address'
-        value={street}
-        onChange={e => setStreet(e.target.value)}
-         />
-        </div>
-        <div className='cityState'>
+          </div>
+          <div className='streetAddress labelTop'><label htmlFor="street">Street Address</label>
+            <input
+              className='longInput colorInput'
+              type="text"
+              placeholder='Street Address'
+              value={street}
+              onChange={e => setStreet(e.target.value)}
+            />
+          </div>
+          <div className='cityState'>
             <div className='city'>
 
-            <label className='cityLabel' htmlFor="city">City</label>
-            <input 
-            className='cityInput colorInput'
-            type="text"
-            placeholder='City'
-            value={city}
-            onChange={e => setCity(e.target.value)}
-             />
-            </div>
-             <div className='normal comma'>,</div>
-            <div className='state'>
-
-             <label className='stateLabel' htmlFor="state">State</label>
-             <input 
-             className='stateInput colorInput'
-             type="text"
-             placeholder='State'
-             value={state}
-             onChange={e => setState(e.target.value)}
+              <label className='cityLabel' htmlFor="city">City</label>
+              <input
+                className='cityInput colorInput'
+                type="text"
+                placeholder='City'
+                value={city}
+                onChange={e => setCity(e.target.value)}
               />
             </div>
-        </div>
-        <div className='cityState'>
+            <div className='normal comma'>,</div>
+            <div className='state'>
+
+              <label className='stateLabel' htmlFor="state">State</label>
+              <input
+                className='stateInput colorInput'
+                type="text"
+                placeholder='State'
+                value={state}
+                onChange={e => setState(e.target.value)}
+              />
+            </div>
+          </div>
+          <div className='cityState'>
             <div className='city'>
 
-            <label className='cityLabel' htmlFor="city">Latitude</label>
-            <input 
-            className='lat colorInput'
-            type="text"
-            placeholder='Latitude'
-            value={lat}
-            onChange={e => setLat(e.target.value)}
-             />
-            </div>
-             <div className='normal comma'>,</div>
-            <div className='state'>
-
-             <label className='stateLabel' htmlFor="state">Longitude</label>
-             <input 
-             className='lng colorInput'
-             type="text"
-             placeholder='Longitude'
-             value={lng}
-             onChange={e => setLng(e.target.value)}
+              <label className='cityLabel' htmlFor="city">Latitude</label>
+              <input
+                className='lat colorInput'
+                type="text"
+                placeholder='Latitude'
+                value={lat}
+                onChange={e => setLat(e.target.value)}
               />
             </div>
+            <div className='normal comma'>,</div>
+            <div className='state'>
+
+              <label className='stateLabel' htmlFor="state">Longitude</label>
+              <input
+                className='lng colorInput'
+                type="text"
+                placeholder='Longitude'
+                value={lng}
+                onChange={e => setLng(e.target.value)}
+              />
+            </div>
+          </div>
+
         </div>
+        <div className='section2 onlyShows'>
+          <h2 className='subheading bottom'>Describe your place to guests</h2>
+          <p className='normal onlyShows'>Mention the best features of your space, any special amentities like fast wifi or parking, and what you love about the neighborhood.</p>
+          <textarea
+          className='colorInput longInput'
+          placeholder='Please write at least 30 characters'
+          name="description"
+          id="description"
+          value={description}
+          onChange={e => setDescription(e.target.value)}
+          ></textarea>
 
         </div>
 
-        </div>
+      </div>
 
     </div>
   )

--- a/frontend/src/screens/CreateSpot/components/main/SpotForm.jsx
+++ b/frontend/src/screens/CreateSpot/components/main/SpotForm.jsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import './SpotForm.css'
 
 
-import { useDispatch} from 'react-redux';
+import { useDispatch } from 'react-redux';
 import { addImageThunk, addSpotThunk } from '../../../../store/spots';
 import { useNavigate } from 'react-router-dom';
 
@@ -33,7 +33,7 @@ export default function SpotForm() {
   useEffect(() => {
     const error = {};
 
-    if (buttonClicked) {
+    
 
 
       if (!country.length) {
@@ -101,9 +101,10 @@ export default function SpotForm() {
         if (!imageFour.endsWith('.png') && !imageFour.endsWith('.jpg') && !imageFour.endsWith('.jpeg')) {
           error.imageFour = 'Image URL must end in .png, .jpg, or .jpeg'
         }
-      }
+      
     }
     setErrors(error)
+    console.log(Object.keys(errors))
   }, [country, address, state, city, lat, lng, description, name, price, previewImage, imageOne, imageTwo, imageThree, imageFour, buttonClicked])
 
 
@@ -113,28 +114,30 @@ export default function SpotForm() {
     e.preventDefault();
     e.stopPropagation();
 
-  
+
+    if (Object.keys(errors).length === 0) {
+
+      const spot = { country, address, state, city, lat, lng, description, name, price }
+      const newSpot = await dispatch(addSpotThunk(spot))
+
+      console.log(newSpot.id)
+
+      const images = [{ url: previewImage, preview: true },
+      { url: imageOne || 'https://st4.depositphotos.com/14953852/24787/v/380/depositphotos_247872612-stock-illustration-no-image-available-icon-vector.jpg', preview: false },
+      { url: imageTwo || 'https://st4.depositphotos.com/14953852/24787/v/380/depositphotos_247872612-stock-illustration-no-image-available-icon-vector.jpg', preview: false },
+      { url: imageThree || 'https://st4.depositphotos.com/14953852/24787/v/380/depositphotos_247872612-stock-illustration-no-image-available-icon-vector.jpg', preview: false },
+      { url: imageFour || 'https://st4.depositphotos.com/14953852/24787/v/380/depositphotos_247872612-stock-illustration-no-image-available-icon-vector.jpg', preview: false },
+      ]
 
 
-    const spot = { country, address, state, city, lat, lng, description, name, price }
-    const newSpot = await dispatch(addSpotThunk(spot))
+      for (let image of images) {
+        await dispatch(addImageThunk(newSpot.id, image))
 
-    console.log(newSpot.id)
-    
-    const images = [{ url: previewImage, preview: true },
-      {url: imageOne || 'https://st4.depositphotos.com/14953852/24787/v/380/depositphotos_247872612-stock-illustration-no-image-available-icon-vector.jpg', preview: false},
-      {url: imageTwo || 'https://st4.depositphotos.com/14953852/24787/v/380/depositphotos_247872612-stock-illustration-no-image-available-icon-vector.jpg', preview: false},
-      {url: imageThree || 'https://st4.depositphotos.com/14953852/24787/v/380/depositphotos_247872612-stock-illustration-no-image-available-icon-vector.jpg', preview: false},
-      {url: imageFour || 'https://st4.depositphotos.com/14953852/24787/v/380/depositphotos_247872612-stock-illustration-no-image-available-icon-vector.jpg', preview: false},
-    ]
-    
+      }
 
-    for (let image of images) {
-      await dispatch(addImageThunk(newSpot.id ,image))
-
+      navigate(`/spots/${newSpot.id}`)
     }
-    navigate(`/spots/${newSpot.id}`)
-    
+
 
   }
 
@@ -149,7 +152,7 @@ export default function SpotForm() {
           <div className='country labelTop'>
             <div className='labelAndError'>
               <label htmlFor="country">Country</label>
-              <div className='error'>{errors.country && errors.country}</div>
+              <div className='error'>{buttonClicked && errors.country && errors.country}</div>
             </div>
             <input
               className='longInput colorInput'
@@ -162,7 +165,7 @@ export default function SpotForm() {
           <div className='streetAddress labelTop'>
             <div className='labelAndError'>
               <label htmlFor="street">Street Address</label>
-              <div className='error'>{errors.address && errors.address}</div>
+              <div className='error'>{buttonClicked &&errors.address && errors.address}</div>
             </div>
             <input
               className='longInput colorInput'
@@ -176,7 +179,7 @@ export default function SpotForm() {
             <div className='city'>
               <div className='labelAndError'>
                 <label className='cityLabel' htmlFor="city">City</label>
-                <div className='error'>{errors.city && errors.city}</div>
+                <div className='error'>{buttonClicked && errors.city && errors.city}</div>
 
               </div>
               <input
@@ -191,7 +194,7 @@ export default function SpotForm() {
             <div className='state'>
               <div className='labelAndError'>
                 <label className='stateLabel' htmlFor="state">State</label>
-                <div className='error'>{errors.state && errors.state}</div>
+                <div className='error'>{buttonClicked && errors.state && errors.state}</div>
 
               </div>
               <input
@@ -207,7 +210,7 @@ export default function SpotForm() {
             <div className='city'>
               <div className='labelAndError'>
                 <label className='cityLabel' htmlFor="latitude">Latitude</label>
-                <div className='error'>{errors.lat && errors.lat}</div>
+                <div className='error'>{buttonClicked && errors.lat && errors.lat}</div>
 
               </div>
               <input
@@ -222,7 +225,7 @@ export default function SpotForm() {
             <div className='state'>
               <div className='labelAndError'>
                 <label className='stateLabel' htmlFor="longitude">Longitude</label>
-                <div className='error'>{errors.lng && errors.lng}</div>
+                <div className='error'>{buttonClicked&& errors.lng && errors.lng}</div>
 
               </div>
 
@@ -248,7 +251,7 @@ export default function SpotForm() {
             value={description}
             onChange={e => setDescription(e.target.value)}
           ></textarea>
-          <div className='error'>{errors.description && errors.description}</div>
+          <div className='error'>{buttonClicked && errors.description && errors.description}</div>
         </div>
         <div className='section2'>
           <h2 className='subheading bottom'>Create a title for your spot</h2>
@@ -260,7 +263,7 @@ export default function SpotForm() {
             value={name}
             onChange={e => setName(e.target.value)}
           />
-          <div className='error'>{errors.name && errors.name}</div>
+          <div className='error'>{buttonClicked && errors.name && errors.name}</div>
         </div>
         <div className='section2'>
           <h2 className='subheading bottom'>Set a base price for your spot</h2>
@@ -276,7 +279,7 @@ export default function SpotForm() {
               onChange={e => setPrice(e.target.value)}
             />
           </div>
-          <div className='error'>{errors.price && errors.price}</div>
+          <div className='error'>{buttonClicked && errors.price && errors.price}</div>
         </div>
         <div className='section2'>
           <h2 className='subheading bottom'>Liven up your spot with photos</h2>
@@ -292,7 +295,7 @@ export default function SpotForm() {
                 value={previewImage}
                 onChange={e => setPreviewImage(e.target.value)}
               />
-              <div className='error'>{errors.preview && errors.preview || errors.image && errors.image}</div>
+              <div className='error'>{buttonClicked && errors.preview && errors.preview ||buttonClicked &&  errors.image && errors.image}</div>
 
             </div>
             <div>
@@ -304,7 +307,7 @@ export default function SpotForm() {
                 value={imageOne}
                 onChange={e => setImageOne(e.target.value)}
               />
-              <div className='error'>{errors.imageOne && errors.imageOne}</div>
+              <div className='error'>{buttonClicked && errors.imageOne && errors.imageOne}</div>
 
             </div>
             <div>
@@ -316,7 +319,7 @@ export default function SpotForm() {
                 value={imageTwo}
                 onChange={e => setImageTwo(e.target.value)}
               />
-              <div className='error'>{errors.imageTwo && errors.imageTwo}</div>
+              <div className='error'>{buttonClicked && errors.imageTwo && errors.imageTwo}</div>
 
             </div>
             <div>
@@ -328,7 +331,7 @@ export default function SpotForm() {
                 value={imageThree}
                 onChange={e => setImageThree(e.target.value)}
               />
-              <div className='error'>{errors.imageThree && errors.imageThree}</div>
+              <div className='error'>{buttonClicked && errors.imageThree && errors.imageThree}</div>
 
             </div>
             <div>
@@ -340,7 +343,7 @@ export default function SpotForm() {
                 value={imageFour}
                 onChange={e => setImageFour(e.target.value)}
               />
-              <div className='error'>{errors.imageFour && errors.imageFour}</div>
+              <div className='error'>{buttonClicked && errors.imageFour && errors.imageFour}</div>
             </div>
           </div>
 

--- a/frontend/src/screens/CreateSpot/components/main/SpotForm.jsx
+++ b/frontend/src/screens/CreateSpot/components/main/SpotForm.jsx
@@ -36,76 +36,76 @@ export default function SpotForm() {
     
 
 
-      if (!country.length) {
+      if (!country.trim().length) {
         error.country = 'Country is required';
       }
 
-      if (!address.length) {
+      if (!address.trim().length) {
         error.address = 'Address is required';
       }
 
-      if (!city.length) {
+      if (!city.trim().length) {
         error.city = 'City is required';
       }
 
-      if (!state.length) {
+      if (!state.trim().length) {
         error.state = 'State is required';
       }
 
-      if (!lat.length) {
+      if (!lat.trim().length) {
         error.lat = 'Latitude is required';
       }
 
-      if (!lng.length) {
+      if (!lng.trim().length) {
         error.lng = 'Longitude is required';
       }
 
-      if (description.length < 30) {
+      if (description.trim().length < 30) {
         error.description = 'Description needs a minimum of 30 characters';
       }
 
-      if (!name.length) {
+      if (!name.trim().length) {
         error.name = 'Name is required';
       }
 
-      if (!price.length) {
+      if (!price.trim().length) {
         error.price = 'Price is required';
       }
 
-      if (!previewImage.length) {
+      if (!previewImage.trim().length) {
         error.preview = 'Preview Image is required'
       }
-      if (previewImage.length) {
+      if (previewImage.trim().length) {
         if (!previewImage.endsWith('.png') && !previewImage.endsWith('.jpg') && !previewImage.endsWith('.jpeg')) {
           error.image = 'Image URL must end in .png, .jpg, or .jpeg'
         }
       }
 
-      if (imageOne.length) {
+      if (imageOne.trim().length) {
         if (!imageOne.endsWith('.png') && !imageOne.endsWith('.jpg') && !imageOne.endsWith('.jpeg')) {
           error.imageOne = 'Image URL must end in .png, .jpg, or .jpeg'
         }
       }
 
-      if (imageTwo.length) {
+      if (imageTwo.trim().length) {
         if (!imageTwo.endsWith('.png') && !imageTwo.endsWith('.jpg') && !imageTwo.endsWith('.jpeg')) {
           error.imageTwo = 'Image URL must end in .png, .jpg, or .jpeg'
         }
       }
-      if (imageThree.length) {
+      if (imageThree.trim().length) {
         if (!imageThree.endsWith('.png') && !imageThree.endsWith('.jpg') && !imageThree.endsWith('.jpeg')) {
           error.imageThree = 'Image URL must end in .png, .jpg, or .jpeg'
         }
       }
-      if (imageFour.length) {
+      if (imageFour.trim().length) {
         if (!imageFour.endsWith('.png') && !imageFour.endsWith('.jpg') && !imageFour.endsWith('.jpeg')) {
           error.imageFour = 'Image URL must end in .png, .jpg, or .jpeg'
         }
       
     }
     setErrors(error)
-    console.log(Object.keys(errors))
-  }, [country, address, state, city, lat, lng, description, name, price, previewImage, imageOne, imageTwo, imageThree, imageFour, buttonClicked, errors])
+    
+  }, [country, address, state, city, lat, lng, description, name, price, previewImage, imageOne, imageTwo, imageThree, imageFour, buttonClicked])
 
 
 
@@ -115,28 +115,44 @@ export default function SpotForm() {
     e.stopPropagation();
 
 
-    if (Object.keys(errors).length === 0) {
-
+    
+      let resOkCount = 0
+      const submitErrors = {};
       const spot = { country, address, state, city, lat, lng, description, name, price }
       const newSpot = await dispatch(addSpotThunk(spot))
+      console.log(newSpot.ok)
 
-      console.log(newSpot.id)
+      if (newSpot.ok) {
 
-      const images = [{ url: previewImage, preview: true },
-      { url: imageOne || 'https://st4.depositphotos.com/14953852/24787/v/380/depositphotos_247872612-stock-illustration-no-image-available-icon-vector.jpg', preview: false },
-      { url: imageTwo || 'https://st4.depositphotos.com/14953852/24787/v/380/depositphotos_247872612-stock-illustration-no-image-available-icon-vector.jpg', preview: false },
-      { url: imageThree || 'https://st4.depositphotos.com/14953852/24787/v/380/depositphotos_247872612-stock-illustration-no-image-available-icon-vector.jpg', preview: false },
-      { url: imageFour || 'https://st4.depositphotos.com/14953852/24787/v/380/depositphotos_247872612-stock-illustration-no-image-available-icon-vector.jpg', preview: false },
-      ]
+        const images = [{ url: previewImage, preview: true },
+        { url: imageOne || 'https://st4.depositphotos.com/14953852/24787/v/380/depositphotos_247872612-stock-illustration-no-image-available-icon-vector.jpg', preview: false },
+        { url: imageTwo || 'https://st4.depositphotos.com/14953852/24787/v/380/depositphotos_247872612-stock-illustration-no-image-available-icon-vector.jpg', preview: false },
+        { url: imageThree || 'https://st4.depositphotos.com/14953852/24787/v/380/depositphotos_247872612-stock-illustration-no-image-available-icon-vector.jpg', preview: false },
+        { url: imageFour || 'https://st4.depositphotos.com/14953852/24787/v/380/depositphotos_247872612-stock-illustration-no-image-available-icon-vector.jpg', preview: false },
+        ]
+  
+  
+        for (let image of images) {
+          const res = await dispatch(addImageThunk(newSpot.id, image))
+          
+          if (res.ok) {
+            resOkCount++
+  
+          } else submitErrors[res] = res
+        }
+        console.log(resOkCount, 'count')
+        if (resOkCount === 5) {
+          
+          navigate(`/spots/${newSpot.id}`)
 
-
-      for (let image of images) {
-        await dispatch(addImageThunk(newSpot.id, image))
-
+        }
+      } else { 
+        submitErrors[newSpot] = newSpot
+        setErrors(submitErrors)
       }
 
-      navigate(`/spots/${newSpot.id}`)
-    }
+
+    
 
 
   }

--- a/frontend/src/screens/CreateSpot/components/main/SpotForm.jsx
+++ b/frontend/src/screens/CreateSpot/components/main/SpotForm.jsx
@@ -1,10 +1,14 @@
 import { useEffect, useState } from 'react';
 import './SpotForm.css'
-import { useDispatch } from 'react-redux';
+
+
+import { useDispatch} from 'react-redux';
+import { addImageThunk, addSpotThunk } from '../../../../store/spots';
+import { useNavigate } from 'react-router-dom';
 
 export default function SpotForm() {
   const [country, setCountry] = useState('');
-  const [street, setStreet] = useState('');
+  const [address, setAddress] = useState('');
   const [city, setCity] = useState('');
   const [state, setState] = useState('');
   const [lat, setLat] = useState('');
@@ -19,91 +23,114 @@ export default function SpotForm() {
   const [imageFour, setImageFour] = useState('')
   const [errors, setErrors] = useState({});
   const [buttonClicked, setButtonClicked] = useState(false)
-
   const dispatch = useDispatch();
+  const navigate = useNavigate();
+
+
+
+
 
   useEffect(() => {
     const error = {};
 
     if (buttonClicked) {
 
-    
-    if (!country.length) {
-      error.country = 'Country is required';
-    }
 
-    if (!street.length) {
-      error.street = 'Address is required';
-    }
+      if (!country.length) {
+        error.country = 'Country is required';
+      }
 
-    if (!city.length) {
-      error.city = 'City is required';
-    }
+      if (!address.length) {
+        error.address = 'Address is required';
+      }
 
-    if (!state.length) {
-      error.state = 'State is required';
-    }
+      if (!city.length) {
+        error.city = 'City is required';
+      }
 
-    if (!lat.length) {
-      error.lat = 'Latitude is required';
-    }
+      if (!state.length) {
+        error.state = 'State is required';
+      }
 
-    if (!lng.length) {
-      error.lng = 'Longitude is required';
-    }
+      if (!lat.length) {
+        error.lat = 'Latitude is required';
+      }
 
-    if (description.length < 30) {
-      error.description = 'Description needs a minimum of 30 characters';
-    }
+      if (!lng.length) {
+        error.lng = 'Longitude is required';
+      }
 
-    if (!name.length) {
-      error.name = 'Name is required';
-    }
+      if (description.length < 30) {
+        error.description = 'Description needs a minimum of 30 characters';
+      }
 
-    if (!price.length) {
-      error.price = 'Price is required';
-    }
+      if (!name.length) {
+        error.name = 'Name is required';
+      }
 
-    if (!previewImage.length) {
-      error.preview = 'Preview Image is required'
-    }
-    if (previewImage.length) {
-      if (!previewImage.endsWith('.png') && !previewImage.endsWith('.jpg') && !previewImage.endsWith('.jpeg')) {
-        error.image = 'Image URL must end in .png, .jpg, or .jpeg'
+      if (!price.length) {
+        error.price = 'Price is required';
+      }
+
+      if (!previewImage.length) {
+        error.preview = 'Preview Image is required'
+      }
+      if (previewImage.length) {
+        if (!previewImage.endsWith('.png') && !previewImage.endsWith('.jpg') && !previewImage.endsWith('.jpeg')) {
+          error.image = 'Image URL must end in .png, .jpg, or .jpeg'
+        }
+      }
+
+      if (imageOne.length) {
+        if (!imageOne.endsWith('.png') && !imageOne.endsWith('.jpg') && !imageOne.endsWith('.jpeg')) {
+          error.imageOne = 'Image URL must end in .png, .jpg, or .jpeg'
+        }
+      }
+
+      if (imageTwo.length) {
+        if (!imageTwo.endsWith('.png') && !imageTwo.endsWith('.jpg') && !imageTwo.endsWith('.jpeg')) {
+          error.imageTwo = 'Image URL must end in .png, .jpg, or .jpeg'
+        }
+      }
+      if (imageThree.length) {
+        if (!imageThree.endsWith('.png') && !imageThree.endsWith('.jpg') && !imageThree.endsWith('.jpeg')) {
+          error.imageThree = 'Image URL must end in .png, .jpg, or .jpeg'
+        }
+      }
+      if (imageFour.length) {
+        if (!imageFour.endsWith('.png') && !imageFour.endsWith('.jpg') && !imageFour.endsWith('.jpeg')) {
+          error.imageFour = 'Image URL must end in .png, .jpg, or .jpeg'
+        }
       }
     }
-
-    if (imageOne.length) {
-      if (!imageOne.endsWith('.png') && !imageOne.endsWith('.jpg') && !imageOne.endsWith('.jpeg')) {
-        error.imageOne = 'Image URL must end in .png, .jpg, or .jpeg'
-      }
-    }
-
-    if (imageTwo.length) {
-      if (!imageTwo.endsWith('.png') && !imageTwo.endsWith('.jpg') && !imageTwo.endsWith('.jpeg')) {
-        error.imageTwo = 'Image URL must end in .png, .jpg, or .jpeg'
-      }
-    }
-    if (imageThree.length) {
-      if (!imageThree.endsWith('.png') && !imageThree.endsWith('.jpg') && !imageThree.endsWith('.jpeg')) {
-        error.imageThree = 'Image URL must end in .png, .jpg, or .jpeg'
-      }
-    }
-    if (imageFour.length) {
-      if (!imageFour.endsWith('.png') && !imageFour.endsWith('.jpg') && !imageFour.endsWith('.jpeg')) {
-        error.imageFour = 'Image URL must end in .png, .jpg, or .jpeg'
-      }
-    }
-  }
     setErrors(error)
-  }, [country, street, state, city, lat, lng, description, name, price, previewImage, imageOne, imageTwo, imageThree, imageFour, buttonClicked])
+  }, [country, address, state, city, lat, lng, description, name, price, previewImage, imageOne, imageTwo, imageThree, imageFour, buttonClicked])
 
 
 
-  const submit = (e) => {
+  const submit = async (e) => {
     setButtonClicked(!buttonClicked)
     e.preventDefault();
     e.stopPropagation();
+    const spot = { country, address, state, city, lat, lng, description, name, price }
+    const newSpot = await dispatch(addSpotThunk(spot))
+
+    console.log(newSpot.id)
+    
+    const images = [{ url: previewImage, preview: true },
+      {url: imageOne || 'https://st4.depositphotos.com/14953852/24787/v/380/depositphotos_247872612-stock-illustration-no-image-available-icon-vector.jpg', preview: false},
+      {url: imageTwo || 'https://st4.depositphotos.com/14953852/24787/v/380/depositphotos_247872612-stock-illustration-no-image-available-icon-vector.jpg', preview: false},
+      {url: imageThree || 'https://st4.depositphotos.com/14953852/24787/v/380/depositphotos_247872612-stock-illustration-no-image-available-icon-vector.jpg', preview: false},
+      {url: imageFour || 'https://st4.depositphotos.com/14953852/24787/v/380/depositphotos_247872612-stock-illustration-no-image-available-icon-vector.jpg', preview: false},
+    ]
+    
+
+    for (let image of images) {
+      await dispatch(addImageThunk(newSpot.id ,image))
+
+    }
+    navigate(`/spots/${newSpot.id}`)
+    
 
   }
 
@@ -131,14 +158,14 @@ export default function SpotForm() {
           <div className='streetAddress labelTop'>
             <div className='labelAndError'>
               <label htmlFor="street">Street Address</label>
-              <div className='error'>{errors.street && errors.street}</div>
+              <div className='error'>{errors.address && errors.address}</div>
             </div>
             <input
               className='longInput colorInput'
               type="text"
               placeholder='Street Address'
-              value={street}
-              onChange={e => setStreet(e.target.value)}
+              value={address}
+              onChange={e => setAddress(e.target.value)}
             />
           </div>
           <div className='cityState'>
@@ -159,8 +186,8 @@ export default function SpotForm() {
             <div className='normal comma'>,</div>
             <div className='state'>
               <div className='labelAndError'>
-              <label className='stateLabel' htmlFor="state">State</label>
-              <div className='error'>{errors.state && errors.state}</div>
+                <label className='stateLabel' htmlFor="state">State</label>
+                <div className='error'>{errors.state && errors.state}</div>
 
               </div>
               <input
@@ -174,11 +201,11 @@ export default function SpotForm() {
           </div>
           <div className='cityState'>
             <div className='city'>
-            <div className='labelAndError'>
-              <label className='cityLabel' htmlFor="latitude">Latitude</label>
-              <div className='error'>{errors.lat && errors.lat}</div>
+              <div className='labelAndError'>
+                <label className='cityLabel' htmlFor="latitude">Latitude</label>
+                <div className='error'>{errors.lat && errors.lat}</div>
 
-            </div>
+              </div>
               <input
                 className='lat colorInput'
                 type="text"
@@ -189,11 +216,11 @@ export default function SpotForm() {
             </div>
             <div className='normal comma'>,</div>
             <div className='state'>
-            <div className='labelAndError'>
-              <label className='stateLabel' htmlFor="longitude">Longitude</label>
-              <div className='error'>{errors.lng && errors.lng}</div>
+              <div className='labelAndError'>
+                <label className='stateLabel' htmlFor="longitude">Longitude</label>
+                <div className='error'>{errors.lng && errors.lng}</div>
 
-            </div>
+              </div>
 
               <input
                 className='lng colorInput'
@@ -240,12 +267,12 @@ export default function SpotForm() {
             <input
               className='colorInput longInput'
               type="text"
-              placeholder='Name of your spot'
+              placeholder='Price per night (USD)'
               value={price}
               onChange={e => setPrice(e.target.value)}
             />
           </div>
-            <div className='error'>{errors.price && errors.price}</div>
+          <div className='error'>{errors.price && errors.price}</div>
         </div>
         <div className='section2'>
           <h2 className='subheading bottom'>Liven up your spot with photos</h2>
@@ -253,62 +280,62 @@ export default function SpotForm() {
 
           <div className='imageInputs'>
             <div>
-            <input
-              className='colorInput longInput'
-              type="url"
+              <input
+                className='colorInput longInput'
+                type="url"
 
-              placeholder='Preview Image URL'
-              value={previewImage}
-              onChange={e => setPreviewImage(e.target.value)}
-            />
-            <div className='error'>{errors.preview && errors.preview || errors.image && errors.image}</div>
-
-            </div>
-            <div>
-            <input
-              className='colorInput longInput'
-              type="url"
-
-              placeholder='Image URL'
-              value={imageOne}
-              onChange={e => setImageOne(e.target.value)}
-            />
-            <div className='error'>{errors.imageOne && errors.imageOne}</div>
+                placeholder='Preview Image URL'
+                value={previewImage}
+                onChange={e => setPreviewImage(e.target.value)}
+              />
+              <div className='error'>{errors.preview && errors.preview || errors.image && errors.image}</div>
 
             </div>
             <div>
-            <input
-              className='colorInput longInput'
-              type="url"
+              <input
+                className='colorInput longInput'
+                type="url"
 
-              placeholder='Image URL'
-              value={imageTwo}
-              onChange={e => setImageTwo(e.target.value)}
-            />
-            <div className='error'>{errors.imageTwo && errors.imageTwo}</div>
-
-            </div>
-            <div>
-            <input
-              className='colorInput longInput'
-              type="url"
-
-              placeholder='Image URL'
-              value={imageThree}
-              onChange={e => setImageThree(e.target.value)}
-            />
-            <div className='error'>{errors.imageThree && errors.imageThree}</div>
+                placeholder='Image URL'
+                value={imageOne}
+                onChange={e => setImageOne(e.target.value)}
+              />
+              <div className='error'>{errors.imageOne && errors.imageOne}</div>
 
             </div>
             <div>
-            <input
-              className='colorInput longInput'
-              type="url"
+              <input
+                className='colorInput longInput'
+                type="url"
 
-              placeholder='Image URL'
-              value={imageFour}
-              onChange={e => setImageFour(e.target.value)}
-            />
+                placeholder='Image URL'
+                value={imageTwo}
+                onChange={e => setImageTwo(e.target.value)}
+              />
+              <div className='error'>{errors.imageTwo && errors.imageTwo}</div>
+
+            </div>
+            <div>
+              <input
+                className='colorInput longInput'
+                type="url"
+
+                placeholder='Image URL'
+                value={imageThree}
+                onChange={e => setImageThree(e.target.value)}
+              />
+              <div className='error'>{errors.imageThree && errors.imageThree}</div>
+
+            </div>
+            <div>
+              <input
+                className='colorInput longInput'
+                type="url"
+
+                placeholder='Image URL'
+                value={imageFour}
+                onChange={e => setImageFour(e.target.value)}
+              />
               <div className='error'>{errors.imageFour && errors.imageFour}</div>
             </div>
           </div>
@@ -319,7 +346,7 @@ export default function SpotForm() {
 
           <button
             onClick={(e) => submit(e)}
-            
+            disabled={Object.keys(errors).length !== 0}
             className='red'
           >Create Spot</button>
         </div>

--- a/frontend/src/screens/ManageSpots/Components/ManageSpots.css
+++ b/frontend/src/screens/ManageSpots/Components/ManageSpots.css
@@ -1,0 +1,60 @@
+.allSpotsContainer{
+    display: flex;
+    flex-direction: row;
+    margin: 0 1.5rem;
+    gap: 2rem;
+    max-width: 1000px;
+    margin-left: auto;
+    margin-right: auto;
+    flex-basis: 21%;
+    flex-wrap: wrap;
+    padding: 20px 5px;
+    
+}
+
+.spotInfo {
+    font-size: 14pt;
+   
+}
+.h1Manage {
+    margin: 0;
+    padding-top: 20px;
+    margin-bottom: .5rem;;
+}
+
+.imageButtons {
+    margin-top: 1rem;
+    display: flex;
+    gap: 1rem;
+}
+
+.allSpotsContainer img {
+    width: 14rem;
+    height: 14rem;
+    border-radius: 3%;
+}
+
+.locationAndRating {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+
+}
+
+.rating {
+    font-size: 14pt;
+    
+}
+
+.star {
+    font-size: 12pt;
+    position: relative;
+    top: .1rem;
+}
+
+.spotPrice {
+    font-weight: bold;
+}
+
+

--- a/frontend/src/screens/ManageSpots/Components/ManageSpots.css
+++ b/frontend/src/screens/ManageSpots/Components/ManageSpots.css
@@ -9,7 +9,7 @@
     flex-basis: 21%;
     flex-wrap: wrap;
     padding: 20px 5px;
-    
+    cursor: pointer;
 }
 
 .spotInfo {

--- a/frontend/src/screens/ManageSpots/Components/ManageSpots.jsx
+++ b/frontend/src/screens/ManageSpots/Components/ManageSpots.jsx
@@ -1,0 +1,53 @@
+import React, { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { getCurrentUserSpotsThunk } from '../../../store/spots';
+import { useDispatch, useSelector } from 'react-redux';
+
+export default function ManageSpots() {
+    const navigate = useNavigate();
+    const dispatch = useDispatch();
+    const spots = useSelector(state => state.spotState.currentUser)
+
+  const [isLoaded, setIsLoaded] = useState(false);
+
+
+  useEffect(() => {
+    //grab data
+    const getData = async () => {
+      dispatch(getCurrentUserSpotsThunk());
+      setIsLoaded(true);
+    }
+
+    if (!isLoaded) {
+      getData();
+    }
+
+  }, [dispatch, isLoaded])
+
+  const goToSpot = (e,spot) => {
+    
+    e.preventDefault();
+    e.stopPropagation();
+    navigate(`/spots/${spot.id}`)
+  }
+
+  if (!isLoaded) {
+    setTimeout(() => {
+      return <h1>Loading</h1>
+    }, 1000
+    )
+  }
+
+
+
+
+  return (
+    <div className='headingAndAddSpot'>
+        <h1 className='heading'>Manage your Spots</h1>
+        <button className='red' onClick={() => navigate('/spots/new')}>Create a new Spot</button>
+
+
+
+    </div>
+  )
+}

--- a/frontend/src/screens/ManageSpots/Components/ManageSpots.jsx
+++ b/frontend/src/screens/ManageSpots/Components/ManageSpots.jsx
@@ -2,11 +2,15 @@ import React, { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { getCurrentUserSpotsThunk } from '../../../store/spots';
 import { useDispatch, useSelector } from 'react-redux';
+import { FaStar } from 'react-icons/fa';
+import './ManageSpots.css'
 
 export default function ManageSpots() {
     const navigate = useNavigate();
     const dispatch = useDispatch();
     const spots = useSelector(state => state.spotState.currentUser)
+    console.log(spots)
+    
 
   const [isLoaded, setIsLoaded] = useState(false);
 
@@ -14,7 +18,7 @@ export default function ManageSpots() {
   useEffect(() => {
     //grab data
     const getData = async () => {
-      dispatch(getCurrentUserSpotsThunk());
+      await dispatch(getCurrentUserSpotsThunk());
       setIsLoaded(true);
     }
 
@@ -32,10 +36,10 @@ export default function ManageSpots() {
   }
 
   if (!isLoaded) {
-    setTimeout(() => {
+    
       return <h1>Loading</h1>
-    }, 1000
-    )
+    
+    
   }
 
 
@@ -43,8 +47,30 @@ export default function ManageSpots() {
 
   return (
     <div className='headingAndAddSpot'>
-        <h1 className='heading'>Manage your Spots</h1>
+        <h1 className='heading h1Manage'>Manage your Spots</h1>
         <button className='red' onClick={() => navigate('/spots/new')}>Create a new Spot</button>
+        <div className='allSpotsContainer'>
+        {spots.map((spot, idx) => (
+        <div key={`${idx}--${spot.id}`} role='tooltip'>
+            
+            <img src={spot.previewImage} />
+            <div className="locationAndRating">
+              <span className="spotLocation spotInfo">{spot.city}, {spot.state} </span>
+              <span className="rating"><FaStar className="star" /> {spot.avgRating ? spot.avgRating : 'New'
+              }</span>
+
+            </div>
+
+            <span className="spotPrice spotInfo">${spot.price}</span><span> night </span>
+
+            <div className='imageButtons'>
+              <button className='red'>update</button>
+              <button className='red'>delete</button>
+            </div>
+          
+        </div>
+      ))}
+        </div>
 
 
 

--- a/frontend/src/screens/ManageSpots/Components/ManageSpots.jsx
+++ b/frontend/src/screens/ManageSpots/Components/ManageSpots.jsx
@@ -42,6 +42,17 @@ export default function ManageSpots() {
     
   }
 
+  const updateSpot = (e, spot) => {
+    e.preventDefault();
+    e.stopPropagation();
+    console.log('update functionality goes here')
+  }
+  const deleteSpot = (e, spot) => {
+    e.preventDefault();
+    e.stopPropagation();
+    console.log('delete functionality goes here')
+  }
+
 
 
 
@@ -51,7 +62,7 @@ export default function ManageSpots() {
         <button className='red' onClick={() => navigate('/spots/new')}>Create a new Spot</button>
         <div className='allSpotsContainer'>
         {spots.map((spot, idx) => (
-        <div key={`${idx}--${spot.id}`} role='tooltip'>
+        <div onClick={e => goToSpot(e,spot)} key={`${idx}--${spot.id}`} role='tooltip'>
             
             <img src={spot.previewImage} />
             <div className="locationAndRating">
@@ -64,8 +75,9 @@ export default function ManageSpots() {
             <span className="spotPrice spotInfo">${spot.price}</span><span> night </span>
 
             <div className='imageButtons'>
-              <button className='red'>update</button>
-              <button className='red'>delete</button>
+              <button onClick={(e, spot) => updateSpot(e, spot)} className='red'>update</button>
+              <button onClick={(e, spot) => deleteSpot(e, spot)}
+              className='red'>delete</button>
             </div>
           
         </div>

--- a/frontend/src/screens/ManageSpots/Components/ManageSpots.jsx
+++ b/frontend/src/screens/ManageSpots/Components/ManageSpots.jsx
@@ -9,7 +9,7 @@ export default function ManageSpots() {
     const navigate = useNavigate();
     const dispatch = useDispatch();
     const spots = useSelector(state => state.spotState.currentUser)
-    console.log(spots)
+    
     
 
   const [isLoaded, setIsLoaded] = useState(false);
@@ -26,7 +26,7 @@ export default function ManageSpots() {
       getData();
     }
 
-  }, [dispatch, isLoaded])
+  }, [dispatch, isLoaded,])
 
   const goToSpot = (e,spot) => {
     

--- a/frontend/src/screens/Splash/components/Splash.css
+++ b/frontend/src/screens/Splash/components/Splash.css
@@ -6,6 +6,7 @@
     max-width: 1000px;
     margin-left: auto;
     margin-right: auto;
+    flex-basis: 21%;
     flex-wrap: wrap;
     padding: 20px 5px;
     cursor: pointer;
@@ -17,8 +18,8 @@
 }
 
 .spotSection img {
-    width: 13rem;
-    height: 13rem;
+    width: 14rem;
+    height: 14rem;
     border-radius: 3%;
 }
 

--- a/frontend/src/screens/Splash/components/Splash.css
+++ b/frontend/src/screens/Splash/components/Splash.css
@@ -3,6 +3,9 @@
     flex-direction: row;
     margin: 0 1.5rem;
     gap: 2rem;
+    max-width: 1000px;
+    margin-left: auto;
+    margin-right: auto;
     flex-wrap: wrap;
     padding: 20px 5px;
     cursor: pointer;
@@ -14,8 +17,8 @@
 }
 
 .spotSection img {
-    width: 17rem;
-    height: 17rem;
+    width: 13rem;
+    height: 13rem;
     border-radius: 3%;
 }
 

--- a/frontend/src/screens/Splash/components/Splash.jsx
+++ b/frontend/src/screens/Splash/components/Splash.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react"
 import { useDispatch, useSelector } from "react-redux"
 import { useNavigate } from "react-router-dom";
-import { getSpotsThunk } from "../../../store/spots";
+import { getCurrentUserSpotsThunk, getSpotsThunk } from "../../../store/spots";
 import { FaStar } from "react-icons/fa6";
 import './Splash.css'
 
@@ -10,14 +10,41 @@ export default function Splash() {
   const navigate= useNavigate();
   const dispatch = useDispatch();
   const spots = useSelector(state => state.spotState.allSpots)
+  const user = useSelector(state => state.session.user);
 
   const [isLoaded, setIsLoaded] = useState(false);
 
+  
 
   useEffect(() => {
     //grab data
+
+
+    
+
+    
     const getData = async () => {
-      dispatch(getSpotsThunk());
+      await dispatch(getCurrentUserSpotsThunk());
+      
+
+      setIsLoaded(true);
+    }
+
+    if (user) {
+
+      getData();
+    }
+    
+
+  }, [dispatch, user])
+
+  useEffect(() => {
+    //grab data
+    
+    
+    const getData = async () => {
+      await dispatch(getSpotsThunk());
+
       setIsLoaded(true);
     }
 
@@ -25,7 +52,7 @@ export default function Splash() {
       getData();
     }
 
-  }, [dispatch, isLoaded])
+  }, [dispatch, isLoaded, user])
 
   const goToSpot = (e,spot) => {
     

--- a/frontend/src/screens/Spot/components/Reviews/Reviews.jsx
+++ b/frontend/src/screens/Spot/components/Reviews/Reviews.jsx
@@ -11,7 +11,7 @@ export default function Reviews() {
     const [isLoaded, setIsLoaded] = useState(false);
     const dispatch = useDispatch();
     const reviews = useSelector(state => state.reviewsState.allReviews)
-    const spot = useSelector(state => state.spotState.singleSpot['spot'])
+    const spot = useSelector(state => state.spotState.singleSpot)
     const sessionUser = useSelector(state => state.session.user);
     const [isOwner, setIsOwner] = useState(false);
     const [alreadyReviewed, setAlreadyReviewed] = useState(false)

--- a/frontend/src/screens/Spot/components/Spot/Spot.jsx
+++ b/frontend/src/screens/Spot/components/Spot/Spot.jsx
@@ -12,13 +12,14 @@ export default function Spot() {
   const { id } = useParams();
   const [isLoaded, setIsLoaded] = useState(false);
   const dispatch = useDispatch();
-  const spot = useSelector(state => state.spotState.singleSpot['spot'])
-  // console.log(spot);
+  
+  const spot = useSelector(state => state.spotState.singleSpot)
+  console.log(spot.SpotImages);
 
   useEffect(() => {
     const getData = async () => {
-      dispatch(getSingleSpotThunk(id));
-      dispatch(getReviewsThunk(id));
+      await dispatch(getSingleSpotThunk(id));
+      await dispatch(getReviewsThunk(id));
       setIsLoaded(true);
     }
 

--- a/frontend/src/screens/Spot/components/Spot/Spot.jsx
+++ b/frontend/src/screens/Spot/components/Spot/Spot.jsx
@@ -14,7 +14,7 @@ export default function Spot() {
   const dispatch = useDispatch();
   
   const spot = useSelector(state => state.spotState.singleSpot)
-  console.log(spot.SpotImages);
+  
 
   useEffect(() => {
     const getData = async () => {

--- a/frontend/src/screens/Spot/components/Spot/Spot.jsx
+++ b/frontend/src/screens/Spot/components/Spot/Spot.jsx
@@ -4,8 +4,9 @@ import { useParams } from "react-router-dom"
 import { getSingleSpotThunk } from "../../../../store/spots";
 import { FaStar } from "react-icons/fa";
 import { getReviewsThunk } from "../../../../store/reviews";
-import Reviews from "../reviews/reviews";
-import './spot.css'
+
+import './Spot.css'
+import Reviews from '../Reviews/Reviews';
 
 
 export default function Spot() {

--- a/frontend/src/store/spots.js
+++ b/frontend/src/store/spots.js
@@ -1,7 +1,7 @@
 import { csrfFetch } from './csrf';
 
 const GET_ALL_SPOTS = 'spots/getAllSpots';
-const GET_USER_SPOTS = 'spots/current'
+const GET_USER_SPOTS = 'spots/getUserSpots'
 const GET_SINGLE_SPOT = 'spots/spot';
 const ADD_SPOT = 'spots/add'
 const ADD_IMAGE = 'spots/images/add'
@@ -76,9 +76,8 @@ export const getCurrentUserSpotsThunk = () => async (dispatch) => {
         const res = await csrfFetch(`/api/spots/current`);
         if (res.ok) {
             const data = await res.json();
-            console.log(data)
-            dispatch(getSingleSpot(data))
             
+            dispatch(getUserSpots(data))
             
         } else {
             throw res
@@ -175,10 +174,8 @@ function spotsReducer(state = initialState, action) {
 
             case GET_USER_SPOTS:
                 newState = { ...state };
-                newState.currentUser = action.payload.spots;
-                for(let spot of action.payload.Spots) {
-                    newState.byId[spot.id] = spot;
-                }
+                newState.currentUser = action.payload.Spots;
+                
 
                 return newState;
 

--- a/frontend/src/store/spots.js
+++ b/frontend/src/store/spots.js
@@ -94,7 +94,7 @@ export const addImageThunk = (id, image) => async (dispatch) => {
             header: {'Content-Type': 'application/json'},
             body: JSON.stringify(image)
         }
-        const res = await csrfFetch(`api/spots/${id}/images`, options)
+        const res = await csrfFetch(`/api/spots/${id}/images`, options)
         console.log(res)
         if (res.ok) {
             const data = await res.json();

--- a/frontend/src/store/spots.js
+++ b/frontend/src/store/spots.js
@@ -80,6 +80,9 @@ export const addSpotThunk = (spot) => async (dispatch) => {
             dispatch(getSingleSpot(data))
             return data;
             
+        } else {
+            
+            throw res
         }
         
     } catch (error) {
@@ -101,6 +104,8 @@ export const addImageThunk = (id, image) => async (dispatch) => {
             dispatch(addImage(id, data))
             return data
 
+        } else {
+            throw res
         }
         
     } catch (error) {

--- a/frontend/src/store/spots.js
+++ b/frontend/src/store/spots.js
@@ -1,6 +1,7 @@
 import { csrfFetch } from './csrf';
 
 const GET_ALL_SPOTS = 'spots/getAllSpots';
+const GET_USER_SPOTS = 'spots/current'
 const GET_SINGLE_SPOT = 'spots/spot';
 const ADD_SPOT = 'spots/add'
 const ADD_IMAGE = 'spots/images/add'
@@ -9,6 +10,10 @@ const ADD_IMAGE = 'spots/images/add'
 // action creator
 const getAllSpots = (spots) => ({
     type: GET_ALL_SPOTS,
+    payload: spots
+})
+const getUserSpots = (spots) => ({
+    type: GET_USER_SPOTS,
     payload: spots
 })
 
@@ -55,6 +60,23 @@ export const getSingleSpotThunk = (id) => async (dispatch) => {
         if (res.ok) {
             const data = await res.json();
             
+            dispatch(getSingleSpot(data))
+            
+            
+        } else {
+            throw res
+        }
+
+    } catch (error) {
+        return error;
+    }
+}
+export const getCurrentUserSpotsThunk = () => async (dispatch) => {
+    try {
+        const res = await csrfFetch(`/api/spots/current`);
+        if (res.ok) {
+            const data = await res.json();
+            console.log(data)
             dispatch(getSingleSpot(data))
             
             
@@ -150,6 +172,16 @@ function spotsReducer(state = initialState, action) {
                 newState.singleSpot.SpotImages = [...newState?.singleSpot?.SpotImages || []]
                 newState.singleSpot.SpotImages.push(action.image)
                 return newState
+
+            case GET_USER_SPOTS:
+                newState = { ...state };
+                newState.currentUser = action.payload.spots;
+                for(let spot of action.payload.Spots) {
+                    newState.byId[spot.id] = spot;
+                }
+
+                return newState;
+
 
         default: 
             return state;

--- a/frontend/src/store/spots.js
+++ b/frontend/src/store/spots.js
@@ -2,6 +2,8 @@ import { csrfFetch } from './csrf';
 
 const GET_ALL_SPOTS = 'spots/getAllSpots';
 const GET_SINGLE_SPOT = 'spots/spot';
+const ADD_SPOT = 'spots/add'
+const ADD_IMAGE = 'spots/images/add'
 
 
 // action creator
@@ -14,6 +16,20 @@ const getSingleSpot = (spot) => ({
     type: GET_SINGLE_SPOT,
     payload: spot
 })
+
+const addSpot = (spot) => ({
+    type: ADD_SPOT,
+    payload: spot
+})
+
+const addImage = (spotId, image) => ({
+    type: ADD_IMAGE,
+    payload: image,
+    spotId
+
+})
+
+
 
 
 
@@ -38,7 +54,9 @@ export const getSingleSpotThunk = (id) => async (dispatch) => {
         const res = await csrfFetch(`/api/spots/${id}`);
         if (res.ok) {
             const data = await res.json();
+            
             dispatch(getSingleSpot(data))
+            
             
         } else {
             throw res
@@ -47,6 +65,48 @@ export const getSingleSpotThunk = (id) => async (dispatch) => {
     } catch (error) {
         return error;
     }
+}
+
+export const addSpotThunk = (spot) => async (dispatch) => {
+    try {
+        const options = {
+            method: 'POST',
+            header: {'Content-Type': 'application/json'},
+            body: JSON.stringify(spot)
+        }
+        const res = await csrfFetch('/api/spots/', options )
+        if (res.ok) {
+            const data = await res.json();
+            dispatch(getSingleSpot(data))
+            return data;
+            
+        }
+        
+    } catch (error) {
+        return error;
+    }
+}
+
+export const addImageThunk = (id, image) => async (dispatch) => {
+    try {
+        const options = {
+            method: 'POST',
+            header: {'Content-Type': 'application/json'},
+            body: JSON.stringify(image)
+        }
+        const res = await csrfFetch(`api/spots/${id}/images`, options)
+        console.log(res)
+        if (res.ok) {
+            const data = await res.json();
+            dispatch(addImage(id, data))
+            return data
+
+        }
+        
+    } catch (error) {
+        return error
+    }
+    
 }
 
 
@@ -72,11 +132,19 @@ function spotsReducer(state = initialState, action) {
             return newState;
         case GET_SINGLE_SPOT:
             newState = { ...state }
-            newState.singleSpot['spot'] = action.payload;
+
+            newState.singleSpot = action.payload;
             
 
             return newState;
-    
+        
+           
+
+            case ADD_IMAGE:
+                newState = { ...state };
+                newState.singleSpot.SpotImages = [...newState?.singleSpot?.SpotImages || []]
+                newState.singleSpot.SpotImages.push(action.image)
+                return newState
 
         default: 
             return state;


### PR DESCRIPTION
# Manage Spots

- [x] When opening the user drop down menu and selecting "Manage Spots", it should navigate the user to the spot management page which shows the the list of all the spots created by the user.
- [x] The spot management page should contain a heading with the text "Manage Spots".
- [ ] If no spots have been posted yet by the user, show a "Create a New Spot" link, which links to the new spot form page, instead of the spot list.
- [x] The spot management page should contain a spot tile list similar to the one in the landing page (thumbnail image, location, rating, price).
- [x] Each spot in the spot tile list on the spot management page should contain an additional two buttons, "Update" and "Delete" buttons, below the city and state.
- [x] Clicking any part of the spot tile should navigate to that spot's detail page.